### PR TITLE
fix: allow webp imports

### DIFF
--- a/src/types/images.d.ts
+++ b/src/types/images.d.ts
@@ -1,0 +1,1 @@
+declare module '*.webp';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "allowArbitraryExtensions": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,


### PR DESCRIPTION
## Summary
- allow arbitrary extensions in TypeScript config
- declare modules for .webp files

## Testing
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c5ea6b2f648333ae9350bdd6cbb3a4