### PR TITLE
fix: cross-platform husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
-# Run lint-staged to format code and run linters
-# Usando cmd.exe para garantir compatibilidade com Windows
-cmd.exe /c "npx lint-staged"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged


### PR DESCRIPTION
## Summary
- replace Windows-specific Husky pre-commit script with standard shell script
- ensure pre-commit hook is executable

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c5ea75d38c83339c79b7a07cfdd972