### PR TITLE
fix: remove hydration suppression and align date usage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -130,7 +130,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-BR" suppressHydrationWarning>
+    <html lang="pt-BR">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />

--- a/src/components/ProjectsShowcase/FeaturedProjects.tsx
+++ b/src/components/ProjectsShowcase/FeaturedProjects.tsx
@@ -337,7 +337,7 @@ const ProjectsShowcase = () => {
                       transition={{ delay: 0.1 }}
                     >
                       <Calendar size={14} />
-                      <span>Created {new Date().getFullYear()}</span>
+                      <span>Created {new Date().getUTCFullYear()}</span>
                     </motion.div>
 
                     {/* Title with animated underline */}

--- a/src/components/interests-cards/InterestsCards.tsx
+++ b/src/components/interests-cards/InterestsCards.tsx
@@ -543,7 +543,9 @@ const InterestsCards = () => {
                   </p>
                   <p className="text-xs text-gray-500 dark:text-gray-400">
                     {lyftaStats?.lastWorkout?.workout_perform_date
-                      ? new Date(lyftaStats.lastWorkout.workout_perform_date).toLocaleDateString()
+                      ? new Date(
+                          lyftaStats.lastWorkout.workout_perform_date
+                        ).toLocaleDateString('en-US', { timeZone: 'UTC' })
                       : '-'}
                   </p>
                 </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -174,7 +174,7 @@ FooterLink.displayName = 'FooterLink';
 
 const Footer = memo(() => {
   const t = useTranslations('Footer');
-  const currentYear = new Date().getFullYear();
+  const currentYear = new Date().getUTCFullYear();
   const [hoveredIcon, setHoveredIcon] = useState<string | null>(null);
   const footerRef = useRef<HTMLDivElement>(null);
   const [featuredProjects, setFeaturedProjects] = useState<Project[]>([]);


### PR DESCRIPTION
## Summary
- remove `suppressHydrationWarning` from root layout
- use UTC dates to avoid server/client mismatches

## Testing
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68c5eac4826883338b489d5f3d5d5d13