### PR TITLE
refactor: dynamically load client components

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 import { PersonStructuredData } from '@/components/SEO/StructuredData';
 import { ContactLinks } from '@/constants/contacts';
-import AboutClient from './client';
+
+const AboutClient = dynamic(() => import('./client'));
 
 export const metadata: Metadata = {
   title: 'Sobre | Lucas Hdo - Desenvolvedor Full Stack',

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next';
-import ContactClient from './client';
+import dynamic from 'next/dynamic';
+
+const ContactClient = dynamic(() => import('./client'));
 
 export const metadata: Metadata = {
   title: 'Contato | Lucas Hdo - Desenvolvedor Full Stack',

--- a/src/app/gallery/[id]/page.tsx
+++ b/src/app/gallery/[id]/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import { galleryItems } from '@/constants/gallery';
-import GalleryItemClient from '@/app/gallery/[id]/client';
+
+const GalleryItemClient = dynamic(() => import('./client'));
 
 interface PageProps {
   params: Promise<{ id: string }>;

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next';
-import GalleryClient from '@/app/gallery/client';
+import dynamic from 'next/dynamic';
+
+const GalleryClient = dynamic(() => import('./client'));
 
 export const metadata: Metadata = {
   title: 'Galeria | Lucas Hdo - Desenvolvedor Full Stack',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,15 @@
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata, Viewport } from 'next';
+import dynamic from 'next/dynamic';
 import { Inter, Roboto_Mono } from 'next/font/google';
 import { IntlProviderClient } from '@/lib/i18n/IntlProviderClient';
-import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import { GoogleAnalytics } from '@/components/SEO/GoogleAnalytics';
 import './globals.css';
 import { logo } from '../../public';
+
+const Header = dynamic(() => import('@/components/layout/Header'));
+const Footer = dynamic(() => import('@/components/layout/Footer'));
 
 const inter = Inter({
   subsets: ['latin'],

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import { projects } from '@/constants';
-import ProjectDetailClient from './client';
+
+const ProjectDetailClient = dynamic(() => import('./client'));
 
 export async function generateStaticParams() {
   return projects.map(p => ({

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 import { ProjectStructuredData } from '@/components/SEO/StructuredData';
 import { projects } from '@/constants';
-import ProjectsClient from './projects-client';
+
+const ProjectsClient = dynamic(() => import('./projects-client'));
 
 export const metadata: Metadata = {
   title: 'Projetos | Lucas Hdo - Desenvolvedor Full Stack',


### PR DESCRIPTION
## Summary
- load client-heavy sections with Next.js dynamic imports in About, Contact, Gallery and Projects pages
- dynamically import layout header and footer to isolate client code

## Testing
- `pnpm build` *(fails: Failed to fetch font `Inter`)*
- `pnpm exec next analyze` *(fails: Invalid project directory provided)*

------
https://chatgpt.com/codex/tasks/task_e_68c5eb0d2270833382688905db8471d8