### PR TITLE
chore: garantir variáveis somente no servidor

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,3 +1,5 @@
+'use server';
+
 // src/lib/supabase/server.ts
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { LastFmUser, LastFmTrack, LastFmArtist } from '@/types/lastfm.types';
 
 // Last.fm API service


### PR DESCRIPTION
## Summary
- adiciona diretiva `use server` nos serviços Last.fm e Supabase
- reforça o uso de variáveis sensíveis apenas no backend

## Testing
- `pnpm lint`
- `pnpm type-check`

------
https://chatgpt.com/codex/tasks/task_e_68c6f2db0b3c8333950de987ec2d8f57