### PR TITLE
fix: allow sitemap in robots

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/_next/', '/admin/', '/private/', '/*.json$', '/*.xml$'],
+        disallow: ['/api/', '/_next/', '/admin/', '/private/'],
       },
       {
         userAgent: 'Googlebot',


### PR DESCRIPTION
## Summary
- remove generic XML/JSON disallow rules from robots config to allow sitemap

## Testing
- `pnpm lint`
- `pnpm type-check`
- `curl -I https://www.google.com/webmasters/tools/robots-testing-tool` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fbd336fc8333ab3dd122a14b039b