### PR TITLE
refactor: dedupe link preconnects

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -135,11 +135,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="pt-BR">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
         <link rel="dns-prefetch" href="https://www.google-analytics.com" />
         <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
         <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link rel="manifest" href="/site.webmanifest" />
         <link rel="icon" type="image/webp" href="/logo.webp" />
         <link rel="apple-touch-icon" href="/logo.webp" />


### PR DESCRIPTION
## Summary
- avoid duplicate preconnects by keeping single connection hint per host

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c6fbc765dc83338baa0af1daa30219