### PR TITLE
feat: fetch GitHub stars server-side

### DIFF
--- a/src/app/projects/[id]/client.tsx
+++ b/src/app/projects/[id]/client.tsx
@@ -56,9 +56,10 @@ const tagVariants: Variants = {
 
 interface ProjectDetailProps {
   project: Project;
+  stars: number;
 }
 
-export const ProjectDetail = ({ project }: ProjectDetailProps) => {
+export const ProjectDetail = ({ project, stars }: ProjectDetailProps) => {
   const [imageLoading, setImageLoading] = useState(true);
   const t = useTranslations('Projects');
   const locale = useLanguageStore(state => state.lang);
@@ -179,6 +180,7 @@ export const ProjectDetail = ({ project }: ProjectDetailProps) => {
             <GitHubStarsButton
               username={project.repoUrl.split('/')[3] || 'LucasHenriqueDiniz'}
               repo={project.repoUrl.split('/')[4] || 'lucashdo'}
+              stars={stars}
             />
           </motion.div>
         </div>
@@ -268,10 +270,16 @@ export const ProjectDetail = ({ project }: ProjectDetailProps) => {
 };
 
 // Main component that wraps ProjectDetail with AnimatedProjectsLayout
-export default function ProjectDetailClient({ project }: { project: Project }) {
+export default function ProjectDetailClient({
+  project,
+  stars,
+}: {
+  project: Project;
+  stars: number;
+}) {
   return (
     <AnimatedProjectsLayout>
-      <ProjectDetail project={project} />
+      <ProjectDetail project={project} stars={stars} />
     </AnimatedProjectsLayout>
   );
 }

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { projects } from '@/constants';
+import { getRepoStars } from '@/services/github';
 
 const ProjectDetailClient = dynamic(() => import('./client'));
 
@@ -38,6 +39,8 @@ export default async function ProjectPage({ params }: { params: Promise<{ id: st
   if (!project) {
     notFound();
   }
+  const [, , , owner = 'LucasHenriqueDiniz', repo = 'lucashdo'] = project.repoUrl.split('/');
+  const stars = await getRepoStars(owner, repo);
 
-  return <ProjectDetailClient project={project} />;
+  return <ProjectDetailClient project={project} stars={stars} />;
 }

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import { cache } from 'react';
+
+/**
+ * Fetch the number of stars for a GitHub repository.
+ * Uses a 1 hour cache to avoid hitting the rate limit frequently.
+ *
+ * @param username - GitHub username or organization
+ * @param repo - Repository name
+ * @returns Number of stargazers
+ */
+export const getRepoStars = cache(async (username: string, repo: string): Promise<number> => {
+  const response = await fetch(`https://api.github.com/repos/${username}/${repo}`, {
+    next: { revalidate: 3600 },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch repository stars');
+  }
+
+  const data = await response.json();
+  return data.stargazers_count ?? 0;
+});


### PR DESCRIPTION
## Summary
- add server-side helper to fetch GitHub repository stars with 1h cache
- use server helper to supply GitHubStarsButton and remove client-side fetching

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c6fbcd372c8333a8853c8aaa8e8271