### PR TITLE
feat(header): add mobile navigation menu

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+public/gallery/live2d

--- a/scripts/check-i18n.ts
+++ b/scripts/check-i18n.ts
@@ -48,21 +48,26 @@ function isKeyUsed(key: string): boolean {
   return false;
 }
 
-const files = readdirSync(messagesDir).filter((f) => f.endsWith('.json'));
+const files = readdirSync(messagesDir).filter(f => f.endsWith('.json'));
 const allKeys = new Set<string>();
 for (const file of files) {
-  const json = JSON.parse(readFileSync(path.join(messagesDir, file), 'utf8')) as Record<string, unknown>;
-  flatten(json).forEach((k) => allKeys.add(k));
+  const json = JSON.parse(readFileSync(path.join(messagesDir, file), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  flatten(json).forEach(k => allKeys.add(k));
 }
 
 const unused: string[] = [];
-Array.from(allKeys).sort().forEach((key) => {
-  if (!isKeyUsed(key)) unused.push(key);
-});
+Array.from(allKeys)
+  .sort()
+  .forEach(key => {
+    if (!isKeyUsed(key)) unused.push(key);
+  });
 
 if (unused.length) {
   console.log('Unused keys:');
-  unused.forEach((k) => console.log(`- ${k}`));
+  unused.forEach(k => console.log(`- ${k}`));
   process.exitCode = 1;
 } else {
   console.log('No unused keys found.');

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,6 +13,14 @@ import {
   HiOutlineMail,
   HiMail,
 } from 'react-icons/hi';
+import { Menu } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
 import { LanguageSwitcher } from '../language-switcher';
 import './header.css';
 import { logo } from '../../../public';
@@ -205,7 +213,10 @@ export default function Header() {
             </Link>
           </motion.div>
 
-          <nav className="flex-1 flex justify-center overflow-x-auto hide-scrollbar">
+          <nav
+            className="hidden md:flex flex-1 justify-center overflow-x-auto hide-scrollbar"
+            aria-label="Main"
+          >
             <ul className="flex gap-2 md:gap-4 lg:gap-6">
               <NavItem
                 href="/projects"
@@ -231,22 +242,70 @@ export default function Header() {
             </ul>
           </nav>
 
-          <motion.div
-            className="flex items-center gap-3 relative"
-            whileHover={{ scale: 1.03 }}
-            whileTap={{ scale: 0.97 }}
-            transition={{ type: 'spring', stiffness: 400, damping: 20 }}
-          >
+          <div className="flex items-center gap-3">
             <motion.div
-              className="absolute -inset-2 rounded-lg opacity-0 hover:opacity-10"
-              style={{
-                background: 'radial-gradient(circle, var(--primary) 0%, transparent 70%)',
-                filter: 'blur(4px)',
-              }}
-              transition={{ duration: 0.3 }}
-            />
-            <LanguageSwitcher />
-          </motion.div>
+              className="hidden md:flex items-center gap-3 relative"
+              whileHover={{ scale: 1.03 }}
+              whileTap={{ scale: 0.97 }}
+              transition={{ type: 'spring', stiffness: 400, damping: 20 }}
+            >
+              <motion.div
+                className="absolute -inset-2 rounded-lg opacity-0 hover:opacity-10"
+                style={{
+                  background: 'radial-gradient(circle, var(--primary) 0%, transparent 70%)',
+                  filter: 'blur(4px)',
+                }}
+                transition={{ duration: 0.3 }}
+              />
+              <LanguageSwitcher />
+            </motion.div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="md:hidden p-2 rounded-md hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  aria-label="Open menu"
+                >
+                  <Menu className="h-6 w-6" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56 md:hidden">
+                <DropdownMenuItem asChild>
+                  <Link
+                    href="/projects"
+                    className="flex items-center gap-2"
+                    aria-current={activeSection === 'projects' ? 'page' : undefined}
+                  >
+                    <HiOutlineFolder className="icon" />
+                    {t('projects') || 'Projetos'}
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link
+                    href="/about"
+                    className="flex items-center gap-2"
+                    aria-current={activeSection === 'about' ? 'page' : undefined}
+                  >
+                    <HiOutlineUser className="icon" />
+                    {t('about') || 'Sobre'}
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link
+                    href="/contact"
+                    className="flex items-center gap-2"
+                    aria-current={activeSection === 'contact' ? 'page' : undefined}
+                  >
+                    <HiOutlineMail className="icon" />
+                    {t('contact') || 'Contato'}
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <div className="px-2 py-1.5">
+                  <LanguageSwitcher />
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
 
         <motion.div
@@ -294,7 +353,7 @@ function NavItem({ href, label, isActive = false, icon, activeIcon }: NavItemPro
 
   return (
     <li>
-      <Link href={href} passHref>
+      <Link href={href} passHref aria-current={isActive ? 'page' : undefined}>
         <motion.div
           className="header-nav-button"
           onMouseEnter={() => setIsHovering(true)}


### PR DESCRIPTION
## Summary
- add mobile dropdown navigation with language switcher
- improve accessibility by marking nav with aria labels and current page

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c5e610f670833399b9870966c423ec