### PR TITLE
feat: improve homepage mobile support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
 import ExpGraph from '@/components/home/ExpGraph';
 import GuestBook from '@/components/home/GuestBook';
 import Hero from '@/components/home/Hero';
@@ -63,7 +64,8 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Home() {
+export default async function Home() {
+  const t = await getTranslations('Home');
   return (
     <>
       <PersonStructuredData
@@ -89,24 +91,32 @@ export default function Home() {
       <WebsiteStructuredData />
       <OrganizationStructuredData />
 
-      <main className="min-h-screen w-full flex flex-col items-center mt-[--navbar-height]">
+      <main className="min-h-screen w-full flex flex-col items-center mt-[--navbar-height] px-4">
         {/* HERO */}
         <Hero />
 
-        {/* Hero Browser */}
-        <HeroBrowser />
+        {/* Desktop-only sections */}
+        <div className="hidden md:flex flex-col items-center w-full">
+          {/* Hero Browser */}
+          <HeroBrowser />
 
-        {/* EXPERIENCE GRAPH */}
-        <ExpGraph />
+          {/* EXPERIENCE GRAPH */}
+          <ExpGraph />
 
-        {/* TIMELINE */}
-        <Timeline />
+          {/* TIMELINE */}
+          <Timeline />
 
-        {/* PROJECTS SHOWCASE */}
-        <ProjectsShowcase />
+          {/* PROJECTS SHOWCASE */}
+          <ProjectsShowcase />
 
-        {/* GUESTBOOK */}
-        <GuestBook />
+          {/* GUESTBOOK */}
+          <GuestBook />
+        </div>
+
+        {/* Mobile placeholder */}
+        <div className="md:hidden w-full max-w-4xl mx-auto my-12 text-center text-muted-foreground">
+          {t('mobilePlaceholder')}
+        </div>
       </main>
     </>
   );

--- a/src/components/ProjectsShowcase/FeaturedProjects.tsx
+++ b/src/components/ProjectsShowcase/FeaturedProjects.tsx
@@ -14,6 +14,7 @@ import {
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { MdFeaturedPlayList } from 'react-icons/md';
+import { useTranslations } from 'next-intl';
 import { useLanguageStore } from '@/lib/i18n/languageStore';
 import { Project, projects } from '@/constants/projects';
 import HomeSectionTitle from '@/components/ui/HomeSectionTitle';
@@ -26,6 +27,7 @@ const ProjectsShowcase = () => {
   const [activeProjectIndex, setActiveProjectIndex] = useState<number>(0);
   const [ShowMouseInfo, setShowMouseInfo] = useState<boolean>(true);
   const lang = useLanguageStore(state => state.lang);
+  const t = useTranslations('FeaturedProjects');
 
   // Sort projects to get featured ones first
   const featuredProjects = projects.filter(project => project.featured);
@@ -120,13 +122,9 @@ const ProjectsShowcase = () => {
   return (
     <section className="w-full max-w-7xl mx-auto my-24 px-4 sm:px-6">
       <HomeSectionTitle
-        subTitle={
-          lang === 'pt'
-            ? 'Veja alguns dos meus projetos em destaque'
-            : 'Check out some of my featured projects'
-        }
-        titleWhitePart={lang === 'pt' ? 'Projetos em' : 'Projects'}
-        titleBluePart={lang === 'pt' ? 'Destaque' : 'Featured'}
+        subTitle={t('subTitle')}
+        titleWhitePart={t('titleWhitePart')}
+        titleBluePart={t('titleBluePart')}
         icon={
           <motion.div
             key={1}
@@ -403,7 +401,7 @@ const ProjectsShowcase = () => {
                           size={16}
                           className="transition-transform group-hover:-translate-y-0.5 group-hover:rotate-3"
                         />
-                        <span>View Code</span>
+                        <span>{t('viewCode')}</span>
                       </Link>
                       {activeProject.demoUrl && (
                         <Link
@@ -416,7 +414,7 @@ const ProjectsShowcase = () => {
                             size={16}
                             className="transition-transform group-hover:-translate-y-0.5 group-hover:rotate-3"
                           />
-                          <span>Live Demo</span>
+                          <span>{t('liveDemo')}</span>
                         </Link>
                       )}
                     </motion.div>
@@ -440,7 +438,7 @@ const ProjectsShowcase = () => {
             href="/projects"
             className="group relative overflow-hidden bg-gradient-to-r from-blue-600/90 to-blue-700/90 hover:from-blue-500/90 hover:to-blue-600/90 text-white font-medium py-3 px-7 rounded-lg shadow-md shadow-blue-900/20 hover:shadow-lg hover:shadow-blue-900/30 transition-all duration-300 flex items-center gap-3"
           >
-            <span className="z-10 relative">View all projects</span>
+            <span className="z-10 relative">{t('viewAllProjects')}</span>
             <motion.span
               className="inline-block z-10 relative"
               animate={{ x: [0, 2, 0] }}

--- a/src/components/home/Browser/Browser.tsx
+++ b/src/components/home/Browser/Browser.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 
+import React, { ReactNode, useCallback, useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { PlusIcon } from 'lucide-react';
-import React, { ReactNode, useCallback, useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { Skeleton } from '@/components/ui/skeleton';
 import './Browser.css';
 import {
@@ -102,6 +103,7 @@ const Browser = function Browser({
   externalActiveTabId,
 }: BrowserProps): React.ReactElement {
   // Browser state
+  const t = useTranslations('Browser');
   const [isMaximized, setIsMaximized] = useState(false);
   const [isMinimized, setIsMinimized] = useState(false);
   const [isClosed, setIsClosed] = useState(false);
@@ -362,8 +364,8 @@ const Browser = function Browser({
             <button
               className="new-tab-btn"
               onClick={handleNewTabClick}
-              aria-label="Nova aba"
-              title="Nova aba"
+              aria-label={t('newTab')}
+              title={t('newTab')}
             >
               <PlusIcon size={16} />
             </button>

--- a/src/components/home/Browser/components/AddressBar.tsx
+++ b/src/components/home/Browser/components/AddressBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { ChevronLeft, ChevronRight, RotateCcw, Search, X, Home } from 'lucide-react';
 import { BrowserTab } from '../types/BrowserTab';
 import './AddressBar.css';
@@ -27,6 +28,7 @@ const AddressBar: React.FC<AddressBarProps> = ({
   const [isRefreshing, setIsRefreshing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const t = useTranslations('Browser');
 
   // Filtrar tabs baseado na pesquisa
   const filteredTabs = availableTabs.filter(availableTab =>
@@ -97,10 +99,10 @@ const AddressBar: React.FC<AddressBarProps> = ({
       <div className="nav-buttons">
         {isInteractive && (
           <>
-            <button className="nav-btn" disabled aria-label="Voltar" title="Voltar">
+            <button className="nav-btn" disabled aria-label={t('back')} title={t('back')}>
               <ChevronLeft size={16} />
             </button>
-            <button className="nav-btn" disabled aria-label="Avançar" title="Avançar">
+            <button className="nav-btn" disabled aria-label={t('forward')} title={t('forward')}>
               <ChevronRight size={16} />
             </button>
           </>
@@ -108,8 +110,8 @@ const AddressBar: React.FC<AddressBarProps> = ({
         <button
           className={`nav-btn refresh-btn ${isRefreshing ? 'refreshing' : ''}`}
           onClick={handleRefresh}
-          aria-label="Recarregar"
-          title="Recarregar"
+          aria-label={t('reload')}
+          title={t('reload')}
         >
           <RotateCcw size={16} />
         </button>
@@ -118,8 +120,8 @@ const AddressBar: React.FC<AddressBarProps> = ({
             className="nav-btn home-btn"
             onClick={handleHomeClick}
             disabled={tab?.type === 'home' || !tab}
-            aria-label="Ir para Home"
-            title={tab?.type === 'home' ? 'Já está na Home' : 'Ir para Home'}
+            aria-label={t('goHome')}
+            title={tab?.type === 'home' ? t('alreadyHome') : t('goHome')}
           >
             <Home size={16} />
           </button>
@@ -150,14 +152,14 @@ const AddressBar: React.FC<AddressBarProps> = ({
               className="search-input"
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
-              placeholder="Pesquisar projetos..."
+              placeholder={t('searchProjects')}
               autoComplete="off"
             />
             {searchQuery && (
               <button
                 className="clear-search-btn"
                 onClick={() => setSearchQuery('')}
-                aria-label="Limpar pesquisa"
+                aria-label={t('clearSearch')}
               >
                 <X size={14} />
               </button>
@@ -165,8 +167,8 @@ const AddressBar: React.FC<AddressBarProps> = ({
           </div>
         ) : (
           <div className="url-display" onClick={isInteractive ? handleUrlClick : undefined}>
-            <span className="url-text">{tab?.url || 'loading...'}</span>
-            {isInteractive && <span className="url-hint">Clique para pesquisar</span>}
+            <span className="url-text">{tab?.url || t('loading')}</span>
+            {isInteractive && <span className="url-hint">{t('clickToSearch')}</span>}
           </div>
         )}
       </div>
@@ -203,7 +205,7 @@ const AddressBar: React.FC<AddressBarProps> = ({
           ) : (
             <div className="no-results">
               <Search size={20} />
-              <span>Nenhum projeto encontrado</span>
+              <span>{t('noProjectsFound')}</span>
             </div>
           )}
         </div>

--- a/src/components/home/Browser/components/DefaultHomeScreen.tsx
+++ b/src/components/home/Browser/components/DefaultHomeScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { BrowserTab } from '../types/BrowserTab';
 import './DefaultHomeScreen.css';
 
@@ -9,6 +10,7 @@ export interface DefaultHomeScreenProps {
 }
 
 const DefaultHomeScreen: React.FC<DefaultHomeScreenProps> = ({ tabs, onTabClick }) => {
+  const t = useTranslations('Browser');
   const handleTabClick = React.useCallback(
     (tabId: string) => {
       onTabClick(tabId);
@@ -18,7 +20,7 @@ const DefaultHomeScreen: React.FC<DefaultHomeScreenProps> = ({ tabs, onTabClick 
 
   return (
     <div className="browser-showcase">
-      <h2 className="browser-showcase-title">Projetos Disponíveis</h2>
+      <h2 className="browser-showcase-title">{t('availableProjects')}</h2>
       <div className="browser-showcase-grid">
         {tabs.map((tab: BrowserTab) => (
           <div
@@ -33,7 +35,7 @@ const DefaultHomeScreen: React.FC<DefaultHomeScreenProps> = ({ tabs, onTabClick 
                 handleTabClick(tab.id);
               }
             }}
-            aria-label={`Abrir ${tab.title}`}
+            aria-label={t('openTab', { title: tab.title })}
           >
             <div className="browser-showcase-card">
               <div className="browser-showcase-icon">
@@ -52,7 +54,7 @@ const DefaultHomeScreen: React.FC<DefaultHomeScreenProps> = ({ tabs, onTabClick 
               <div className="browser-showcase-content">
                 <h3 className="browser-showcase-title">{tab.title}</h3>
                 <div className="browser-showcase-url">{tab.url}</div>
-                <div className="browser-showcase-action">Visitar →</div>
+                <div className="browser-showcase-action">{t('visit')}</div>
               </div>
             </div>
           </div>

--- a/src/components/home/Browser/components/Tab.tsx
+++ b/src/components/home/Browser/components/Tab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { BrowserTab } from '../types/BrowserTab';
 import './Tab.css';
 
@@ -31,6 +32,7 @@ const Tab = React.memo(
       },
       ref
     ) => {
+      const t = useTranslations('Browser');
       const handleClick = React.useCallback(() => {
         if (!tab.isDisabled) {
           onClick(tabIndex);
@@ -89,7 +91,7 @@ const Tab = React.memo(
           <div className="tab-title">
             {tab.title}
             {tab.hasUnsavedChanges && (
-              <span className="tab-unsaved-indicator" title="Mudanças não salvas">
+              <span className="tab-unsaved-indicator" title={t('unsavedChanges')}>
                 •
               </span>
             )}
@@ -99,8 +101,8 @@ const Tab = React.memo(
             <button
               className="tab-close-btn"
               onClick={handleClose}
-              aria-label={`Fechar aba ${tab.title}`}
-              title={`Fechar aba ${tab.title}`}
+              aria-label={t('closeTab', { title: tab.title })}
+              title={t('closeTab', { title: tab.title })}
             >
               &times;
             </button>

--- a/src/components/home/Browser/components/TabPreviewTooltip.tsx
+++ b/src/components/home/Browser/components/TabPreviewTooltip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HouseIcon } from 'lucide-react';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 import { BrowserTab } from '../types/BrowserTab';
 import './TabPreviewTooltip.css';
 
@@ -13,6 +14,7 @@ export interface TabPreviewTooltipProps {
 
 const TabPreviewTooltip = React.memo<TabPreviewTooltipProps>(
   ({ tab, open, reference, placement = 'top' }) => {
+    const t = useTranslations('Browser');
     const [position, setPosition] = React.useState({ x: 0, y: 0 });
     const [isVisible, setIsVisible] = React.useState(false);
 
@@ -84,7 +86,7 @@ const TabPreviewTooltip = React.memo<TabPreviewTooltipProps>(
             <div className="tab-preview-title">{tab.title}</div>
             <div className="tab-preview-url">{tab.url}</div>
             {tab.hasUnsavedChanges && (
-              <div className="tab-preview-unsaved">Mudanças não salvas</div>
+              <div className="tab-preview-unsaved">{t('unsavedChanges')}</div>
             )}
           </div>
           <div className="tab-preview-image">

--- a/src/components/home/ExpGraph/ExpGraph.tsx
+++ b/src/components/home/ExpGraph/ExpGraph.tsx
@@ -2,9 +2,9 @@
 import { flip, arrow as floatingArrow, offset, shift, useFloating } from '@floating-ui/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { SkillDataType, skillsData } from '@/constants';
 import HomeSectionTitle from '@/components/ui/HomeSectionTitle';
-import { useLanguageStore } from '@/lib/i18n/languageStore';
 import './ExpGraph.css';
 
 // Simplified skill icon component for the grid
@@ -239,7 +239,7 @@ const ExpGraph = () => {
   const [hoveredSkill, setHoveredSkill] = useState<string | null>(null);
   const [currentSkillIndex, setCurrentSkillIndex] = useState(0);
   const [showAllSkills, setShowAllSkills] = useState(false);
-  const lang = useLanguageStore(state => state.lang);
+  const t = useTranslations('ExpGraph');
 
   // Sort skills by order for display
   const orderedSkills = [...skillsData].sort((a, b) => (a.order || 999) - (b.order || 999));
@@ -356,12 +356,8 @@ const ExpGraph = () => {
                   >
                     <span>
                       {showAllSkills
-                        ? lang === 'pt'
-                          ? 'Mostrar Menos'
-                          : 'Show Less'
-                        : lang === 'pt'
-                          ? `Mostrar Todos ${orderedSkills.length} Skills`
-                          : `Show All ${orderedSkills.length} Skills`}
+                        ? t('showLess')
+                        : t('showAll', { total: orderedSkills.length })}
                     </span>
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -388,22 +384,18 @@ const ExpGraph = () => {
                   className="w-3 h-3 rounded"
                   style={{ backgroundColor: 'var(--primary)' }}
                 ></div>
-                <span className="text-xs text-gray-400">
-                  {lang === 'pt' ? 'Trabalhando' : 'Working'}
-                </span>
+                <span className="text-xs text-gray-400">{t('legend.working')}</span>
               </div>
               <div className="flex items-center space-x-2">
                 <div
                   className="w-3 h-3 rounded"
                   style={{ backgroundColor: 'var(--popover)' }}
                 ></div>
-                <span className="text-xs text-gray-400">{lang === 'pt' ? 'Total' : 'Total'}</span>
+                <span className="text-xs text-gray-400">{t('legend.total')}</span>
               </div>
               <div className="flex items-center space-x-2">
                 <div className="w-3 h-3 rounded" style={{ backgroundColor: 'var(--cyan)' }}></div>
-                <span className="text-xs text-gray-400">
-                  {lang === 'pt' ? 'Favorito' : 'Favorite'}
-                </span>
+                <span className="text-xs text-gray-400">{t('legend.favorite')}</span>
               </div>
             </div>
           </div>
@@ -412,9 +404,9 @@ const ExpGraph = () => {
             {/* Single large background icon */}
             <div className="relative z-10">
               <HomeSectionTitle
-                subTitle={lang === 'pt' ? 'Onde sou bom' : 'Where I excel'}
-                titleWhitePart={lang === 'pt' ? 'Minhas' : 'My'}
-                titleBluePart={lang === 'pt' ? 'Skills' : 'Skills'}
+                subTitle={t('subTitle')}
+                titleWhitePart={t('titleWhitePart')}
+                titleBluePart={t('titleBluePart')}
                 icon={
                   <motion.div
                     key={currentSkillIndex}

--- a/src/components/home/GuestBook.tsx
+++ b/src/components/home/GuestBook.tsx
@@ -10,7 +10,6 @@ import Avatar from 'boring-avatars';
 import HomeSectionTitle from '@/components/ui/HomeSectionTitle';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { GUESTBOOK_EMOJIS } from '@/constants/guestbookEmojis';
-import { useLanguageStore } from '@/lib/i18n/languageStore';
 import { useGuestbookStore } from '@/store/guestbookStore';
 import { GuestbookEntry } from '@/types/guestbook.types';
 import CarouselGuestbook from './CarouselGuestbook';
@@ -35,7 +34,6 @@ const useDebounce = <T,>(value: T, delay: number): T => {
 
 const GuestBook: React.FC = () => {
   const t = useTranslations('ModernGuestBook');
-  const lang = useLanguageStore(state => state.lang);
   const { entries, isLoading, error, fetchEntries, addEntry } = useGuestbookStore();
   const [formData, setFormData] = useState({
     name: '',
@@ -292,9 +290,9 @@ const GuestBook: React.FC = () => {
       <div className="relative z-10">
         <div className="flex justify-center mb-6 w-full">
           <HomeSectionTitle
-            subTitle={lang === 'pt' ? 'Deixe sua marca aqui!' : 'Leave your mark here!'}
-            titleWhitePart={lang === 'pt' ? 'Livro de' : 'Guest'}
-            titleBluePart={lang === 'pt' ? 'Visitas' : 'Book'}
+            subTitle={t('subtitle')}
+            titleWhitePart={t('titleWhitePart')}
+            titleBluePart={t('titleBluePart')}
             icon={
               <motion.div
                 key={1}

--- a/src/components/home/Hero/AnimatedRole.tsx
+++ b/src/components/home/Hero/AnimatedRole.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useTranslations } from 'next-intl';
 import { TranslatedField } from '@/types/experience.types';
 
 interface DeveloperCompletion {
@@ -13,6 +14,7 @@ interface AnimatedRoleProps {
 
 const AnimatedRole: React.FC<AnimatedRoleProps> = React.memo(({ lang }) => {
   const [roleIndex, setRoleIndex] = useState(0);
+  const t = useTranslations('Hero');
 
   const roles: DeveloperCompletion[] = [
     { text: { pt: 'front-end pleno', en: 'mid-level front-end developer' }, emoji: '💻' },
@@ -41,7 +43,7 @@ const AnimatedRole: React.FC<AnimatedRoleProps> = React.memo(({ lang }) => {
     return () => clearInterval(interval);
   }, [roles.length]);
 
-  const prefix = lang === 'pt' ? 'Um desenvolvedor' : 'A developer';
+  const prefix = t('developerPrefix');
   const currentRole = roles[roleIndex];
   const roleText = currentRole.text[lang];
 

--- a/src/components/home/Hero/Hero.tsx
+++ b/src/components/home/Hero/Hero.tsx
@@ -144,7 +144,7 @@ function HeroComponent() {
     >
       {/* AVISO DE CONSTRUÇÃO MELHORADO */}
       <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20">
-        <div className="px-4 py-2 rounded-full border border-[var(--primary)] text-[var(--primary)] text-sm flex items-center gap-2">
+        <div className="px-4 py-2 rounded-full border border-[var(--primary)] text-[var(--primary)] text-xs sm:text-sm flex items-center gap-2">
           <span className="w-2 h-2 rounded-full bg-[var(--primary)] animate-pulse" />
           Website under construction!
         </div>
@@ -156,7 +156,7 @@ function HeroComponent() {
           id="tsparticles"
           particlesLoaded={particlesLoaded}
           options={networkPreset}
-          className="absolute inset-0 -z-10"
+          className="absolute inset-0 -z-10 hidden md:block"
         />
       )}
 
@@ -188,7 +188,7 @@ function HeroComponent() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.1 }}
         >
-          {lang === 'pt' ? 'Olá, eu sou ' : "Hello, I'm "}
+          {t('Home.greeting')}{' '}
           <span className="relative bg-gradient-to-r from-blue-400 via-cyan-400 to-blue-600 bg-clip-text text-transparent font-extrabold">
             Lucas HDO
             <motion.div
@@ -270,7 +270,7 @@ function HeroComponent() {
 
       {/* "See more projects" indicator  */}
       <motion.div
-        className="absolute bottom-8 left-0 right-0 mx-auto w-fit flex flex-col items-center gap-2 cursor-pointer"
+        className="absolute bottom-8 left-0 right-0 mx-auto w-fit hidden md:flex flex-col items-center gap-2 cursor-pointer"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 1, duration: 0.5 }}
@@ -282,7 +282,7 @@ function HeroComponent() {
         whileTap={{ scale: 0.95 }}
       >
         <span className="text-sm font-medium text-muted-foreground">
-          {t('Home.viewProjects') || (lang === 'pt' ? 'Navegue pelos projetos' : 'Browse Projects')}
+          {t('Home.browseProjects')}
         </span>
 
         <motion.div

--- a/src/components/home/Timeline/Timeline.tsx
+++ b/src/components/home/Timeline/Timeline.tsx
@@ -125,6 +125,7 @@ const ExperienceCard = memo(
     isAcademic?: boolean;
     lang: 'pt' | 'en';
   }) => {
+    const t = useTranslations('Timeline');
     return (
       <div className="card-container mx-2 py-6 px-4 h-full rounded-xl transition-colors">
         <motion.div
@@ -157,13 +158,7 @@ const ExperienceCard = memo(
               },
             }}
           >
-            {isAcademic
-              ? lang === 'pt'
-                ? 'Educação'
-                : 'Education'
-              : lang === 'pt'
-                ? 'Trabalho'
-                : 'Job'}
+            {isAcademic ? t('education') : t('job')}
           </motion.div>
           <motion.div
             className="top-tag-pill institution"
@@ -487,9 +482,9 @@ const Timeline = () => {
   return (
     <section ref={sectionRef} className="w-full flex flex-col items-center justify-center">
       <HomeSectionTitle
-        subTitle="A timeline of my journey"
-        titleWhitePart="My"
-        titleBluePart="Career"
+        subTitle={t('subTitle')}
+        titleWhitePart={t('titleWhitePart')}
+        titleBluePart={t('titleBluePart')}
       />
       <div
         ref={timelineRef}

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -3,13 +3,8 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { Languages } from 'lucide-react';
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { useLanguageStore } from '@/lib/i18n/languageStore';
-
-// Configuração de idiomas
-const languages = {
-  pt: { name: 'Português' },
-  en: { name: 'English' },
-};
 
 type Locale = 'pt' | 'en';
 
@@ -18,6 +13,12 @@ export function LanguageSwitcher() {
   const setLang = useLanguageStore(state => state.setLang);
   const [isHovered, setIsHovered] = useState(false);
   const [previewLanguage, setPreviewLanguage] = useState<Locale | null>(null);
+  const t = useTranslations('Language');
+
+  const languageNames: Record<Locale, string> = {
+    pt: t('portuguese'),
+    en: t('english'),
+  };
 
   const handleLanguageChange = (newLanguage: Locale) => {
     setLang(newLanguage);
@@ -60,7 +61,7 @@ export function LanguageSwitcher() {
                 className="flex items-center"
               >
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  {languages[previewLanguage].name}
+                  {languageNames[previewLanguage]}
                 </span>
               </motion.div>
             ) : (
@@ -73,7 +74,7 @@ export function LanguageSwitcher() {
                 className="flex items-center"
               >
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  {languages[lang].name}
+                  {languageNames[lang]}
                 </span>
               </motion.div>
             )}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -334,6 +334,24 @@
       "favorite": "Favorite"
     }
   },
+  "Browser": {
+    "newTab": "New tab",
+    "unsavedChanges": "Unsaved changes",
+    "closeTab": "Close tab {title}",
+    "openTab": "Open {title}",
+    "visit": "Visit \u2192",
+    "availableProjects": "Available Projects",
+    "back": "Back",
+    "forward": "Forward",
+    "reload": "Reload",
+    "goHome": "Go Home",
+    "alreadyHome": "Already on Home",
+    "searchProjects": "Search projects...",
+    "clearSearch": "Clear search",
+    "loading": "loading...",
+    "clickToSearch": "Click to search",
+    "noProjectsFound": "No projects found"
+  },
   "Timeline": {
     "subTitle": "A timeline of my journey",
     "titleWhitePart": "My",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -16,6 +16,13 @@
     "projectsTitle": "Featured Projects",
     "makeContact": "Get in touch"
   },
+  "Language": {
+    "english": "English",
+    "portuguese": "Portuguese"
+  },
+  "Hero": {
+    "developerPrefix": "A developer"
+  },
   "Home": {
     "title": "Hello, I'm Lucas",
     "subtitle": "Developer & Designer",
@@ -25,7 +32,10 @@
     "latestPosts": "Latest Posts",
     "viewAll": "View All",
     "viewProject": "View Project",
-    "readMore": "Read More"
+    "readMore": "Read More",
+    "greeting": "Hello, I'm",
+    "browseProjects": "Browse Projects",
+    "mobilePlaceholder": "More sections coming soon to mobile."
   },
   "About": {
     "title": "About Me",
@@ -264,6 +274,8 @@
   "ModernGuestBook": {
     "title": "Guest Book",
     "subtitle": "Leave your mark here! ✨",
+    "titleWhitePart": "Guest",
+    "titleBluePart": "Book",
     "rulesTitle": "Guestbook Rules:",
     "rule1": "• Maximum 3 posts every 15 minutes",
     "rule2": "• 2 minutes interval between posts",
@@ -302,7 +314,32 @@
     "messageTooShortHint": "Minimum {min} characters (missing {current})",
     "emojiRules": "Choose an emoji that represents your mood or personality!"
   },
+  "FeaturedProjects": {
+    "subTitle": "Check out some of my featured projects",
+    "titleWhitePart": "Projects",
+    "titleBluePart": "Featured",
+    "viewCode": "View Code",
+    "liveDemo": "Live Demo",
+    "viewAllProjects": "View all projects"
+  },
+  "ExpGraph": {
+    "subTitle": "Where I excel",
+    "titleWhitePart": "My",
+    "titleBluePart": "Skills",
+    "showLess": "Show Less",
+    "showAll": "Show All {total} Skills",
+    "legend": {
+      "working": "Working",
+      "total": "Total",
+      "favorite": "Favorite"
+    }
+  },
   "Timeline": {
+    "subTitle": "A timeline of my journey",
+    "titleWhitePart": "My",
+    "titleBluePart": "Career",
+    "education": "Education",
+    "job": "Job",
     "join_timeline": "Want to be the next company in my timeline?",
     "click_here": "Click here to get in touch"
   }

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -328,5 +328,23 @@
       "total": "Total",
       "favorite": "Favorito"
     }
+  },
+  "Browser": {
+    "newTab": "Nova aba",
+    "unsavedChanges": "Mudanças não salvas",
+    "closeTab": "Fechar aba {title}",
+    "openTab": "Abrir {title}",
+    "visit": "Visitar \u2192",
+    "availableProjects": "Projetos Disponíveis",
+    "back": "Voltar",
+    "forward": "Avançar",
+    "reload": "Recarregar",
+    "goHome": "Ir para Home",
+    "alreadyHome": "Já está na Home",
+    "searchProjects": "Pesquisar projetos...",
+    "clearSearch": "Limpar pesquisa",
+    "loading": "carregando...",
+    "clickToSearch": "Clique para pesquisar",
+    "noProjectsFound": "Nenhum projeto encontrado"
   }
 }

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -16,6 +16,13 @@
     "projectsTitle": "Projetos em destaque",
     "makeContact": "Entrar em contato"
   },
+  "Language": {
+    "english": "Inglês",
+    "portuguese": "Português"
+  },
+  "Hero": {
+    "developerPrefix": "Um desenvolvedor"
+  },
   "Home": {
     "title": "Olá, sou Lucas",
     "subtitle": "Desenvolvedor & Designer",
@@ -25,7 +32,10 @@
     "latestPosts": "Posts Recentes",
     "viewAll": "Ver todos",
     "viewProject": "Ver Projeto",
-    "readMore": "Ler mais"
+    "readMore": "Ler mais",
+    "greeting": "Olá, eu sou",
+    "browseProjects": "Navegue pelos projetos",
+    "mobilePlaceholder": "Mais seções em breve na versão mobile."
   },
   "About": {
     "title": "Sobre Mim",
@@ -202,6 +212,11 @@
     "viewCode": "Ver Código"
   },
   "Timeline": {
+    "subTitle": "Linha do tempo da minha jornada",
+    "titleWhitePart": "Minha",
+    "titleBluePart": "Carreira",
+    "education": "Educação",
+    "job": "Trabalho",
     "join_timeline": "Quer ser a próxima empresa na minha timeline?",
     "click_here": "Clique aqui para entrar em contato"
   },
@@ -254,6 +269,8 @@
   "ModernGuestBook": {
     "title": "Livro de Visitas",
     "subtitle": "Deixe sua marca aqui! ✨",
+    "titleWhitePart": "Livro de",
+    "titleBluePart": "Visitas",
     "rulesTitle": "Regras do Guestbook:",
     "rule1": "• Máximo 3 posts a cada 15 minutos",
     "rule2": "• Intervalo de 2 minutos entre posts",
@@ -291,5 +308,25 @@
     "unexpectedError": "❌ Erro inesperado. Tente novamente mais tarde.",
     "messageTooShortHint": "Mínimo {min} caracteres (faltam {current})",
     "emojiRules": "Escolha um emoji que represente seu humor ou personalidade!"
+  },
+  "FeaturedProjects": {
+    "subTitle": "Veja alguns dos meus projetos em destaque",
+    "titleWhitePart": "Projetos em",
+    "titleBluePart": "Destaque",
+    "viewCode": "Ver Código",
+    "liveDemo": "Demo ao Vivo",
+    "viewAllProjects": "Ver todos os projetos"
+  },
+  "ExpGraph": {
+    "subTitle": "Onde sou bom",
+    "titleWhitePart": "Minhas",
+    "titleBluePart": "Skills",
+    "showLess": "Mostrar Menos",
+    "showAll": "Mostrar Todos {total} Skills",
+    "legend": {
+      "working": "Trabalhando",
+      "total": "Total",
+      "favorite": "Favorito"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- hide desktop-only sections on small screens
- tune hero component and add mobile placeholder
- replace hardcoded strings with translation keys across components

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c7210930bc8333b34d50177232ff28